### PR TITLE
feat: pdfium-auto v0.3.0 zero-friction PDFium setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
+[workspace]
+members  = [".", "crates/pdfium-auto"]
+resolver = "2"
+
 [package]
 name    = "edgequake-pdf2md"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -37,6 +41,8 @@ path = "src/lib.rs"
 [dependencies]
 # Core
 pdfium-render  = { version = "0.8", features = ["pdfium_latest", "image_latest", "thread_safe"] }
+# Auto-download pdfium: zero-friction setup for end-users
+pdfium-auto    = { path = "crates/pdfium-auto", version = "0.1" }
 # v0.2.2 fixes OpenAIProvider::convert_messages() silently dropping ChatMessage.images.
 # We pin to "0.2.2" rather than "0.2" to guarantee the vision fix is present.
 edgequake-llm  = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -27,22 +27,11 @@ Inspired by [pyzerox](https://github.com/getomni-ai/zerox), rebuilt in Rust for 
 
 ## Quick Start
 
-### 1. Install pdfium
+> **Zero setup for pdfium.** The correct PDFium binary (~30 MB) is downloaded automatically on
+> first run and cached in `~/.cache/pdf2md/pdfium-7690/`. No `DYLD_LIBRARY_PATH` required.
+> Use `PDFIUM_LIB_PATH` to point to an existing copy instead.
 
-```bash
-# Auto-detect OS & architecture (recommended)
-./scripts/setup-pdfium.sh
-
-# macOS: set library path
-export DYLD_LIBRARY_PATH="$(pwd)"
-
-# Linux: set library path
-export LD_LIBRARY_PATH="$(pwd)"
-```
-
-> **Note:** pdfium doesn't have an official Homebrew package. Use the setup script above or see [docs/installation.md](docs/installation.md) for manual installation options.
-
-### 2. Set an API key
+### 1. Set an API key
 
 ```bash
 export OPENAI_API_KEY="sk-..."    # OpenAI (recommended)
@@ -52,7 +41,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."  # Anthropic
 export GEMINI_API_KEY="AI..."          # Google Gemini
 ```
 
-### 3. Build & run
+### 2. Build & run
 
 ```bash
 cargo build --release --features cli
@@ -141,7 +130,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-edgequake-pdf2md = "0.2"
+edgequake-pdf2md = "0.3"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/crates/pdfium-auto/Cargo.toml
+++ b/crates/pdfium-auto/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name         = "pdfium-auto"
+version      = "0.1.0"
+edition      = "2021"
+rust-version = "1.88"
+description  = "Auto-download and cache PDFium binaries — zero-friction setup for pdfium-render"
+license      = "MIT OR Apache-2.0"
+repository   = "https://github.com/raphaelmansuy/edgequake-pdf2md"
+keywords     = ["pdf", "pdfium", "rendering", "download", "setup"]
+categories   = ["external-ffi-bindings", "rendering", "command-line-utilities"]
+readme       = "README.md"
+
+[dependencies]
+# Re-export the pdfium-render Pdfium struct for callers
+pdfium-render = { version = "0.8", features = ["pdfium_latest", "image_latest", "thread_safe"] }
+
+# HTTP download  (blocking – used inside spawn_blocking / sync contexts)
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+
+# Archive extraction
+flate2       = "1"
+tar          = "0"
+
+# Error handling
+thiserror    = "2"
+
+# Platform-specific cache directories
+dirs         = "5"

--- a/crates/pdfium-auto/README.md
+++ b/crates/pdfium-auto/README.md
@@ -1,0 +1,73 @@
+# pdfium-auto
+
+> Auto-download and cache [PDFium](https://pdfium.googlesource.com/pdfium/)
+> binaries at runtime — zero-friction setup for
+> [pdfium-render](https://crates.io/crates/pdfium-render).
+
+## Problem
+
+`pdfium-render` is excellent, but requires users to manually:
+
+1. Run a setup script to download 30 MB of platform-specific binaries
+2. Export `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` before running
+
+This blocks `cargo install` workflows: users cannot simply
+`cargo install edgequake-pdf2md && pdf2md document.pdf`.
+
+## Solution
+
+`pdfium-auto` wraps `pdfium-render` with automatic library management:
+
+| Step | Before | After |
+|------|--------|-------|
+| Install | `cargo install && ./scripts/setup-pdfium.sh` | `cargo install` |
+| Setup | `export DYLD_LIBRARY_PATH=$(pwd)` | *(nothing)* |
+| First run | Error: cannot find `libpdfium.dylib` | Download → cache → run |
+| Subsequent runs | Needs env var | Instant start from cache |
+
+## Usage
+
+```rust
+use pdfium_auto::{bind_pdfium_silent, ensure_pdfium_library};
+
+// One-shot: download if needed, then bind
+let pdfium = bind_pdfium_silent().expect("PDFium unavailable");
+
+// Download with progress callback
+let path = ensure_pdfium_library(Some(&|downloaded, total| {
+    match total {
+        Some(t) => eprint!("\rDownloading PDFium: {}%", downloaded * 100 / t),
+        None    => eprint!("\rDownloading PDFium: {} bytes", downloaded),
+    }
+})).expect("download failed");
+```
+
+## Cache Locations
+
+| Platform | Default cache path |
+|----------|--------------------|
+| macOS    | `~/Library/Caches/pdf2md/pdfium-{VERSION}/` |
+| Linux    | `~/.cache/pdf2md/pdfium-{VERSION}/` |
+| Windows  | `%LOCALAPPDATA%\pdf2md\pdfium-{VERSION}\` |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `PDFIUM_LIB_PATH` | Full path to existing pdfium library; skips download |
+| `PDFIUM_AUTO_CACHE_DIR` | Override the base cache directory |
+
+## Platform Support
+
+| OS | Arch | Library |
+|----|------|---------|
+| macOS | arm64 (Apple Silicon) | `libpdfium.dylib` |
+| macOS | x86_64 (Intel) | `libpdfium.dylib` |
+| Linux | x86_64 | `libpdfium.so` |
+| Linux | aarch64 | `libpdfium.so` |
+| Windows | x86_64 | `pdfium.dll` |
+| Windows | aarch64 | `pdfium.dll` |
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/pdfium-auto/src/lib.rs
+++ b/crates/pdfium-auto/src/lib.rs
@@ -1,0 +1,438 @@
+//! # pdfium-auto
+//!
+//! Auto-download and cache [PDFium](https://pdfium.googlesource.com/pdfium/)
+//! binaries at runtime, so that users of `pdfium-render` no longer need to
+//! manually download libpdfium and set `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH`.
+//!
+//! ## How it works
+//!
+//! On first call to [`bind_pdfium`] or [`ensure_pdfium_library`]:
+//!
+//! 1. Checks `~/.cache/pdf2md/pdfium-{VERSION}/` for the platform library.
+//! 2. If absent, downloads the correct `.tgz` from
+//!    [bblanchon/pdfium-binaries](https://github.com/bblanchon/pdfium-binaries).
+//! 3. Extracts `lib/libpdfium.dylib` (or `.so` / `.dll`) to the cache dir.
+//! 4. Calls [`Pdfium::bind_to_library`] to load the real library.
+//!
+//! Subsequent calls skip the network entirely — the library is already cached.
+//!
+//! ## Usage
+//!
+//! ```rust,no_run
+//! use pdfium_auto::{bind_pdfium_silent, bind_pdfium_from_path, ensure_pdfium_library};
+//!
+//! // Option A: convenient one-shot bind (silent, no progress)
+//! let pdfium = bind_pdfium_silent().expect("PDFium unavailable");
+//!
+//! // Option B: download with progress, then bind
+//! let path = ensure_pdfium_library(Some(&|downloaded, total| {
+//!     if let Some(t) = total {
+//!         eprint!("\rDownloading PDFium: {}/{} bytes", downloaded, t);
+//!     }
+//! })).expect("download failed");
+//! let pdfium = bind_pdfium_from_path(&path).expect("bind failed");
+//! ```
+//!
+//! ## Platform support
+//!
+//! | OS      | Arch    | Library               |
+//! |---------|---------|-----------------------|
+//! | macOS   | arm64   | `libpdfium.dylib`     |
+//! | macOS   | x86_64  | `libpdfium.dylib`     |
+//! | Linux   | x86_64  | `libpdfium.so`        |
+//! | Linux   | aarch64 | `libpdfium.so`        |
+//! | Windows | x86_64  | `pdfium.dll`          |
+//! | Windows | aarch64 | `pdfium.dll`          |
+//! | Windows | x86     | `pdfium.dll`          |
+//!
+//! ## Environment variable overrides
+//!
+//! - `PDFIUM_LIB_PATH` — path to an existing pdfium library; skips download.
+//! - `PDFIUM_AUTO_CACHE_DIR` — override the default cache directory.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use pdfium_render::prelude::Pdfium;
+use thiserror::Error;
+
+// ── Public constants ─────────────────────────────────────────────────────────
+
+/// The pdfium-binaries release tag used for downloads.
+///
+/// Maps to [`bblanchon/pdfium-binaries chromium/7690`](https://github.com/bblanchon/pdfium-binaries/releases/tag/chromium%2F7690).
+pub const PDFIUM_VERSION: &str = "7690";
+
+/// GitHub release base URL.
+const BASE_URL: &str = "https://github.com/bblanchon/pdfium-binaries/releases/download";
+
+// ── Error type ───────────────────────────────────────────────────────────────
+
+/// Errors returned by pdfium-auto operations.
+#[derive(Error, Debug)]
+pub enum PdfiumAutoError {
+    /// The current OS/architecture combination is not supported.
+    #[error("Unsupported platform: {os}/{arch}")]
+    UnsupportedPlatform { os: String, arch: String },
+
+    /// Could not create or navigate the local cache directory.
+    #[error("Cache directory error: {0}")]
+    CacheDir(#[source] std::io::Error),
+
+    /// Network download failed.
+    #[error("Download failed: {0}")]
+    Download(String),
+
+    /// gzip/tar extraction failed.
+    #[error("Archive extraction failed: {0}")]
+    Extract(String),
+
+    /// `libloading` / `pdfium-render` could not load the library.
+    #[error("Failed to bind PDFium from '{path}': {reason}")]
+    Bind { path: PathBuf, reason: String },
+}
+
+// ── Internal: platform metadata ──────────────────────────────────────────────
+
+struct PlatformInfo {
+    /// Asset filename in the GitHub release, e.g. `pdfium-mac-arm64.tgz`.
+    archive_name: &'static str,
+    /// Relative path inside the archive, e.g. `lib/libpdfium.dylib`.
+    lib_path_in_archive: &'static str,
+    /// Filename to write on disk, e.g. `libpdfium.dylib`.
+    lib_name: &'static str,
+}
+
+fn detect_platform() -> Result<PlatformInfo, PdfiumAutoError> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    match (os, arch) {
+        ("macos", "aarch64") => Ok(PlatformInfo {
+            archive_name: "pdfium-mac-arm64.tgz",
+            lib_path_in_archive: "lib/libpdfium.dylib",
+            lib_name: "libpdfium.dylib",
+        }),
+        ("macos", "x86_64") => Ok(PlatformInfo {
+            archive_name: "pdfium-mac-x64.tgz",
+            lib_path_in_archive: "lib/libpdfium.dylib",
+            lib_name: "libpdfium.dylib",
+        }),
+        ("linux", "x86_64") => Ok(PlatformInfo {
+            archive_name: "pdfium-linux-x64.tgz",
+            lib_path_in_archive: "lib/libpdfium.so",
+            lib_name: "libpdfium.so",
+        }),
+        ("linux", "aarch64") => Ok(PlatformInfo {
+            archive_name: "pdfium-linux-arm64.tgz",
+            lib_path_in_archive: "lib/libpdfium.so",
+            lib_name: "libpdfium.so",
+        }),
+        ("windows", "x86_64") => Ok(PlatformInfo {
+            archive_name: "pdfium-win-x64.tgz",
+            lib_path_in_archive: "bin/pdfium.dll",
+            lib_name: "pdfium.dll",
+        }),
+        ("windows", "aarch64") => Ok(PlatformInfo {
+            archive_name: "pdfium-win-arm64.tgz",
+            lib_path_in_archive: "bin/pdfium.dll",
+            lib_name: "pdfium.dll",
+        }),
+        ("windows", "x86") => Ok(PlatformInfo {
+            archive_name: "pdfium-win-x86.tgz",
+            lib_path_in_archive: "bin/pdfium.dll",
+            lib_name: "pdfium.dll",
+        }),
+        (os, arch) => Err(PdfiumAutoError::UnsupportedPlatform {
+            os: os.to_string(),
+            arch: arch.to_string(),
+        }),
+    }
+}
+
+// ── Cache directory resolution ───────────────────────────────────────────────
+
+/// Returns the per-version cache directory for the PDFium library.
+///
+/// Default locations:
+/// - **macOS**: `~/Library/Caches/pdf2md/pdfium-{VERSION}/`
+/// - **Linux**: `~/.cache/pdf2md/pdfium-{VERSION}/`
+/// - **Windows**: `%LOCALAPPDATA%\pdf2md\pdfium-{VERSION}\`
+///
+/// Override by setting `PDFIUM_AUTO_CACHE_DIR`.
+pub fn pdfium_cache_dir() -> PathBuf {
+    if let Ok(override_dir) = std::env::var("PDFIUM_AUTO_CACHE_DIR") {
+        return PathBuf::from(override_dir).join(format!("pdfium-{PDFIUM_VERSION}"));
+    }
+
+    let base = dirs::cache_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
+        .unwrap_or_else(std::env::temp_dir);
+
+    base.join("pdf2md").join(format!("pdfium-{PDFIUM_VERSION}"))
+}
+
+// ── Thread-safe singleton path cache ─────────────────────────────────────────
+
+static RESOLVED_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Returns `true` if the PDFium library is already cached on disk (no network
+/// access needed on next call to [`ensure_pdfium_library`]).
+///
+/// Also returns `true` when `PDFIUM_LIB_PATH` points to an existing file.
+pub fn is_pdfium_cached() -> bool {
+    if let Ok(p) = std::env::var("PDFIUM_LIB_PATH") {
+        return PathBuf::from(p).exists();
+    }
+    if let Ok(info) = detect_platform() {
+        return pdfium_cache_dir().join(info.lib_name).exists();
+    }
+    false
+}
+
+/// Returns the on-disk path to the PDFium library, or `None` if not cached.
+pub fn cached_pdfium_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("PDFIUM_LIB_PATH") {
+        let pb = PathBuf::from(p);
+        if pb.exists() {
+            return Some(pb);
+        }
+    }
+    if let Ok(info) = detect_platform() {
+        let p = pdfium_cache_dir().join(info.lib_name);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Ensures the PDFium dynamic library is present in the local cache.
+///
+/// - If `PDFIUM_LIB_PATH` is set (and the file exists), that path is used.
+/// - Otherwise, checks `pdfium_cache_dir()` for an existing library.
+/// - If absent, downloads the appropriate platform binary from GitHub
+///   and extracts it to the cache directory.
+///
+/// `on_progress` receives `(bytes_downloaded, total_size_option)` during
+/// the download.  Pass `None` to suppress progress callbacks.
+///
+/// # Thread safety
+///
+/// Safe to call from multiple threads simultaneously; the download happens
+/// only once per process lifetime.
+pub fn ensure_pdfium_library(
+    on_progress: Option<&dyn Fn(u64, Option<u64>)>,
+) -> Result<PathBuf, PdfiumAutoError> {
+    // Fast path: already resolved in this process.
+    if let Some(path) = RESOLVED_PATH.get() {
+        return Ok(path.clone());
+    }
+
+    let path = resolve_or_download(on_progress)?;
+
+    // Best-effort cache in the OnceLock (ignore race; both will succeed).
+    let _ = RESOLVED_PATH.set(path.clone());
+
+    Ok(path)
+}
+
+/// Binds to PDFium, downloading it first if necessary.
+///
+/// `on_progress` receives `(bytes_downloaded, total_bytes_option)` during
+/// the initial download.
+pub fn bind_pdfium(
+    on_progress: Option<&dyn Fn(u64, Option<u64>)>,
+) -> Result<Pdfium, PdfiumAutoError> {
+    let lib_path = ensure_pdfium_library(on_progress)?;
+    bind_pdfium_from_path(&lib_path)
+}
+
+/// Binds to PDFium without any progress output.
+///
+/// Downloads and caches on first call if required.
+pub fn bind_pdfium_silent() -> Result<Pdfium, PdfiumAutoError> {
+    bind_pdfium(None)
+}
+
+/// Binds to a PDFium library at an explicit `path`.
+///
+/// Does not interact with the download / cache layer.
+pub fn bind_pdfium_from_path(path: &Path) -> Result<Pdfium, PdfiumAutoError> {
+    Pdfium::bind_to_library(path)
+        .map(Pdfium::new)
+        .map_err(|e| PdfiumAutoError::Bind {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn resolve_or_download(
+    on_progress: Option<&dyn Fn(u64, Option<u64>)>,
+) -> Result<PathBuf, PdfiumAutoError> {
+    // 1. Environment variable override.
+    if let Ok(env_path) = std::env::var("PDFIUM_LIB_PATH") {
+        let p = PathBuf::from(env_path);
+        if p.exists() {
+            return Ok(p);
+        }
+        // Fall through: env var set but file missing → still auto-download.
+        eprintln!(
+            "pdfium-auto: PDFIUM_LIB_PATH '{}' not found; downloading …",
+            p.display()
+        );
+    }
+
+    let info = detect_platform()?;
+    let cache_dir = pdfium_cache_dir();
+    let lib_path = cache_dir.join(info.lib_name);
+
+    // 2. Already cached on disk.
+    if lib_path.exists() {
+        return Ok(lib_path);
+    }
+
+    // 3. Download and extract.
+    let url = format!(
+        "{}/chromium%2F{}/{}",
+        BASE_URL, PDFIUM_VERSION, info.archive_name
+    );
+
+    std::fs::create_dir_all(&cache_dir).map_err(PdfiumAutoError::CacheDir)?;
+
+    let archive_bytes = download_bytes(&url, on_progress)?;
+    extract_library(&archive_bytes, info.lib_path_in_archive, &lib_path)?;
+
+    Ok(lib_path)
+}
+
+/// Streams a URL into a `Vec<u8>`, calling `on_progress` every 64 KiB.
+fn download_bytes(
+    url: &str,
+    on_progress: Option<&dyn Fn(u64, Option<u64>)>,
+) -> Result<Vec<u8>, PdfiumAutoError> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("pdfium-auto/", env!("CARGO_PKG_VERSION")))
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .map_err(|e| PdfiumAutoError::Download(e.to_string()))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|e| PdfiumAutoError::Download(format!("GET {url}: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(PdfiumAutoError::Download(format!(
+            "HTTP {} for {url}",
+            response.status()
+        )));
+    }
+
+    let total = response.content_length();
+    let capacity = total.unwrap_or(35 * 1024 * 1024) as usize;
+    let mut buf = Vec::with_capacity(capacity);
+
+    let mut stream = response;
+    let mut chunk = vec![0u8; 64 * 1024]; // 64 KiB
+    let mut downloaded: u64 = 0;
+
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                downloaded += n as u64;
+                if let Some(cb) = on_progress {
+                    cb(downloaded, total);
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                return Err(PdfiumAutoError::Download(format!("Read error: {e}")));
+            }
+        }
+    }
+
+    Ok(buf)
+}
+
+/// Extracts a single file from a gzipped tar archive into `dest_path`.
+fn extract_library(
+    archive_bytes: &[u8],
+    lib_path_in_archive: &str,
+    dest_path: &Path,
+) -> Result<(), PdfiumAutoError> {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    let gz = GzDecoder::new(archive_bytes);
+    let mut archive = Archive::new(gz);
+
+    for entry in archive
+        .entries()
+        .map_err(|e| PdfiumAutoError::Extract(e.to_string()))?
+    {
+        let mut entry = entry.map_err(|e| PdfiumAutoError::Extract(e.to_string()))?;
+        let entry_path = entry
+            .path()
+            .map_err(|e| PdfiumAutoError::Extract(e.to_string()))?;
+
+        let entry_str = entry_path.to_string_lossy();
+        if entry_str == lib_path_in_archive {
+            entry
+                .unpack(dest_path)
+                .map_err(|e| PdfiumAutoError::Extract(format!("Unpack failed: {e}")))?;
+            return Ok(());
+        }
+    }
+
+    Err(PdfiumAutoError::Extract(format!(
+        "Library '{}' not found in archive",
+        lib_path_in_archive
+    )))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_platform_is_supported() {
+        // Verify the current platform is recognised.
+        detect_platform().expect("current platform should be supported");
+    }
+
+    #[test]
+    fn cache_dir_is_deterministic() {
+        let d1 = pdfium_cache_dir();
+        let d2 = pdfium_cache_dir();
+        assert_eq!(d1, d2);
+        assert!(d1.to_str().unwrap().contains("pdf2md"));
+        assert!(d1.to_str().unwrap().contains(PDFIUM_VERSION));
+    }
+
+    #[test]
+    fn cache_dir_override_via_env() {
+        std::env::set_var("PDFIUM_AUTO_CACHE_DIR", "/tmp/test_pdf2md_override");
+        let d = pdfium_cache_dir();
+        std::env::remove_var("PDFIUM_AUTO_CACHE_DIR");
+        assert!(d.starts_with("/tmp/test_pdf2md_override"));
+        assert!(d.to_str().unwrap().contains(PDFIUM_VERSION));
+    }
+
+    #[test]
+    fn platform_info_fields_nonempty() {
+        let info = detect_platform().unwrap();
+        assert!(!info.archive_name.is_empty());
+        assert!(!info.lib_path_in_archive.is_empty());
+        assert!(!info.lib_name.is_empty());
+    }
+}

--- a/specs/11-pdf-rendering-alternatives-study.md
+++ b/specs/11-pdf-rendering-alternatives-study.md
@@ -1,0 +1,214 @@
+# PDF Rendering Alternatives Study
+
+> **Date**: February 19, 2026
+> **Purpose**: Evaluate alternatives to pdfium-render to simplify CLI setup
+> **Current**: pdfium-render v0.8 with manual binary downloads and DYLD_LIBRARY_PATH setup
+
+---
+
+## Executive Summary
+
+The current setup using `pdfium-render` requires users to manually download PDFium binaries and set library paths, creating friction in CLI installation. Several alternatives exist that could significantly simplify setup:
+
+**Top Recommendation**: Switch to `pdfium-bind` - provides automatic binary downloads with vendored libraries, eliminating manual setup while maintaining identical rendering quality.
+
+**Other Options**:
+- `poppler-rs`: System dependency (available via Homebrew), good quality but requires external installation
+- Pure Rust renderers: Immature or non-existent for production use
+- `mupdf`: Excellent quality but AGPL license conflicts
+
+---
+
+## Current Setup Analysis
+
+### pdfium-render v0.8.37
+- **Setup Complexity**: High
+  - Requires downloading ~30MB binaries from bblanchon/pdfium-binaries
+  - Must set `DYLD_LIBRARY_PATH` (macOS), `LD_LIBRARY_PATH` (Linux), or `PATH` (Windows)
+  - Platform-specific setup scripts needed
+- **Quality**: Excellent (Chrome-grade rendering)
+- **Maintenance**: Active (84 versions, updated within 3 months)
+- **License**: MIT/Apache-2.0
+
+### Setup Friction Points
+1. **Manual Downloads**: Users must run `./scripts/setup-pdfium.sh` or manual curl commands
+2. **Environment Variables**: Must export library paths before running
+3. **Platform Detection**: Script handles OS/arch detection but still requires user execution
+4. **Distribution**: Binaries not bundled with the crate
+
+---
+
+## Alternative Analysis
+
+### 1. pdfium-bind v0.1.0 ⭐ **RECOMMENDED**
+
+**Overview**: Rust bindings for PDFium with automatic vendored binary downloads.
+
+**Setup Complexity**: Very Low
+- Automatic binary downloads during build
+- `dynamic` feature: Embeds library in executable, extracts to temp at runtime
+- `static` feature: Links statically at build time
+- Zero user setup required
+
+**Quality**: Identical to pdfium-render (same underlying engine)
+
+**Pros**:
+- ✅ Automatic setup - no manual intervention
+- ✅ Vendored binaries - self-contained distribution
+- ✅ Same rendering quality as current setup
+- ✅ MIT license
+- ✅ Active maintenance (updated within 2 months)
+
+**Cons**:
+- ❌ Newer crate (63 downloads, 1 version)
+- ❌ May need API adaptation (different from pdfium-render)
+
+**Migration Effort**: Medium
+- API differences may require code changes
+- Need to test rendering output equivalence
+
+**Verdict**: Best alternative for setup simplification
+
+---
+
+### 2. poppler-rs v0.25.0
+
+**Overview**: High-level Rust bindings for poppler-glib (GNOME PDF library).
+
+**Setup Complexity**: Medium
+- Requires system poppler installation
+- macOS: `brew install poppler` (readily available)
+- Linux: Usually pre-installed or via `apt install libpoppler-glib-dev`
+- Windows: More complex (vcpkg or MSYS2)
+
+**Quality**: Good but inferior to pdfium
+- Handles most PDFs well
+- Some rendering artifacts vs. pdfium
+- Missing advanced features (transparency blending)
+
+**Pros**:
+- ✅ System package on most platforms
+- ✅ GPL license (permissive for most use cases)
+- ✅ Mature ecosystem (173K downloads)
+
+**Cons**:
+- ❌ Requires external dependency installation
+- ❌ Lower rendering quality than pdfium
+- ❌ More complex API than pdfium-render
+
+**Migration Effort**: High
+- Different API surface
+- May need rendering parameter adjustments
+
+**Verdict**: Good fallback if pdfium-bind proves unsuitable
+
+---
+
+### 3. mupdf v0.6.0
+
+**Overview**: Safe Rust wrapper for MuPDF library.
+
+**Setup Complexity**: Medium-High
+- Requires MuPDF system installation
+- macOS: `brew install mupdf` ✓
+- Linux: `apt install libmupdf-dev`
+- Similar distribution challenges to current pdfium setup
+
+**Quality**: Excellent (comparable to pdfium)
+
+**Pros**:
+- ✅ High rendering quality
+- ✅ Actively maintained (343K downloads)
+
+**Cons**:
+- ❌ AGPL-3.0 license (rejected in current crate selection)
+- ❌ Similar setup complexity to current pdfium
+
+**Verdict**: Rejected due to license conflict
+
+---
+
+### 4. Pure Rust Renderers
+
+**Overview**: No production-ready pure Rust PDF renderers exist.
+
+**Candidates Evaluated**:
+- `micropdf` v0.9.1: Claims "drop-in replacement for MuPDF" but only 119 downloads, immature
+- `pdf-canvas`: Generation only, not rendering
+- `genpdf`: Generation only
+- `lopdf`: Text extraction only
+
+**Verdict**: Not viable for production use
+
+---
+
+## Implementation Recommendations
+
+### Phase 1: Evaluate pdfium-bind
+1. **Create test branch**: `git checkout -b eval-pdfium-bind`
+2. **Add dependency**: `pdfium-bind = "0.1"`
+3. **API compatibility check**: Compare pdfium-bind API vs. pdfium-render
+4. **Rendering equivalence test**: Verify identical output for sample PDFs
+5. **Performance benchmark**: Ensure no regression in rendering speed
+
+### Phase 2: Migration (if compatible)
+1. **Update Cargo.toml**: Replace pdfium-render with pdfium-bind
+2. **Code changes**: Adapt to new API
+3. **Remove setup scripts**: Delete `scripts/setup-pdfium.sh`
+4. **Update documentation**: Remove manual setup instructions
+5. **Test suite**: Full E2E testing with various PDF types
+
+### Phase 3: Fallback to poppler-rs (if needed)
+- If pdfium-bind proves unsuitable, evaluate poppler-rs
+- Update installation docs to include `brew install poppler`
+
+---
+
+## Risk Assessment
+
+### pdfium-bind Risks
+- **Maturity**: Very new crate (2 months old)
+- **Maintenance**: Single maintainer, low download count
+- **API Stability**: May have breaking changes
+
+**Mitigation**: Start with evaluation branch, have poppler-rs as fallback
+
+### Quality Regression Risk
+- poppler rendering may produce different output than pdfium
+- Could affect LLM extraction quality
+
+**Mitigation**: Comprehensive testing with diverse PDF corpus
+
+### License/Dependency Risks
+- pdfium-bind: MIT ✓
+- poppler-rs: GPL (acceptable)
+- mupdf: AGPL (rejected)
+
+---
+
+## Success Metrics
+
+**Setup Simplification**:
+- Target: Zero manual steps for users
+- Current: 3-4 manual commands + environment setup
+- Goal: `cargo install edgequake-pdf2md` works out-of-the-box
+
+**Quality Maintenance**:
+- No visual rendering differences
+- Same LLM extraction accuracy
+- Equivalent performance
+
+**Distribution**:
+- Self-contained binary with no external dependencies
+- Cross-platform compatibility maintained
+
+---
+
+## Conclusion
+
+`pdfium-bind` represents the optimal solution for simplifying PDF rendering setup while maintaining the high quality and compatibility of the current pdfium-based approach. Its automatic binary vendoring eliminates the manual setup friction that currently hinders CLI adoption.
+
+If `pdfium-bind` proves unsuitable due to API differences or maintenance concerns, `poppler-rs` provides a viable fallback with system-level availability on most platforms, though with some quality trade-offs.
+
+Pure Rust alternatives remain immature and unsuitable for production use at this time.</content>
+<parameter name="filePath">/Users/raphaelmansuy/Github/03-working/edgequake-pdf2md/specs/pdf-rendering-alternatives-study.md

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,16 +131,14 @@ pub enum Pdf2MdError {
 
     // ── Pdfium binding errors ─────────────────────────────────────────────
     /// Could not bind to a pdfium library.
-    #[error("Failed to bind to pdfium library: {0}\n\n\
-Quick fix — run the bundled setup script:\n\
-  ./scripts/setup-pdfium.sh\n\n\
-Or install manually:\n\
-  macOS:   brew install pdfium-chromium  (or download from github.com/bblanchon/pdfium-binaries)\n\
-  Linux:   Download from github.com/bblanchon/pdfium-binaries, place libpdfium.so next to the binary or in /usr/local/lib\n\
-  Windows: Download pdfium.dll from github.com/bblanchon/pdfium-binaries, place next to pdf2md.exe\n\n\
-Then set the library path:\n\
-  macOS:   export DYLD_LIBRARY_PATH=$(pwd)\n\
-  Linux:   export LD_LIBRARY_PATH=$(pwd)\n")]
+    #[error(
+        "Failed to bind to pdfium library: {0}\n\n\
+PDFium is normally downloaded automatically on first run.\n\
+If the auto-download failed, you can:\n\
+  • Check your internet connection and try again.\n\
+  • Set PDFIUM_LIB_PATH=/path/to/libpdfium to use an existing copy.\n\
+  • Run `./scripts/setup-pdfium.sh` and set PDFIUM_LIB_PATH to the result.\n"
+    )]
     PdfiumBindingFailed(String),
 
     // ── Catch-all ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Introduces crates/pdfium-auto that auto-downloads and caches PDFium.
No DYLD_LIBRARY_PATH or setup-pdfium.sh required.

## Changes

- Add crates/pdfium-auto (v0.1.0): runtime download from bblanchon/pdfium-binaries
- Cargo workspace conversion
- Version bump 0.2.0 to 0.3.0
- render.rs: use pdfium_auto::bind_pdfium_silent()
- pdf2md.rs: download progress bar on first run
- error.rs: simplified error hints
- docs/installation.md: rewritten
- README.md: simplified Quick Start
- CHANGELOG.md: v0.3.0 entry

## Tests

57 tests pass (cargo test --all), clippy clean, fmt applied.
