### PR TITLE
fix(callbacks): on_page_error &str → String — fix HRTB Send issue in async_trait (closes #8, closes #9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.88"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ impl ConversionProgressCallback for MyProgress {
     fn on_page_complete(&self, page: usize, total: usize, chars: usize) {
         eprintln!("  ✓ Page {page}/{total} — {chars} chars");
     }
-    fn on_page_error(&self, page: usize, total: usize, error: &str) {
+    fn on_page_error(&self, page: usize, total: usize, error: String) {
         eprintln!("  ✗ Page {page}/{total} failed: {error}");
     }
     fn on_conversion_complete(&self, total: usize, success: usize) {

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -131,7 +131,7 @@ impl ConversionProgressCallback for CliProgressCallback {
         self.bar.inc(1);
     }
 
-    fn on_page_error(&self, page_num: usize, total: usize, error: &str) {
+    fn on_page_error(&self, page_num: usize, total: usize, error: String) {
         let elapsed_ms = self
             .start_times
             .lock()
@@ -144,9 +144,9 @@ impl ConversionProgressCallback for CliProgressCallback {
 
         // Truncate very long error messages to keep output tidy.
         let msg = if error.len() > 80 {
-            format!("{}…", &error[..79])
+            format!("{}\u{2026}", &error[..79])
         } else {
-            error.to_string()
+            error
         };
 
         self.bar.println(format!(

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -386,7 +386,7 @@ async fn process_concurrent(
             if let Some(ref cb) = config_clone.progress_callback {
                 match &result.error {
                     None => cb.on_page_complete(page_num, total_pages, result.markdown.len()),
-                    Some(e) => cb.on_page_error(page_num, total_pages, &e.to_string()),
+                    Some(e) => cb.on_page_error(page_num, total_pages, e.to_string()),
                 }
             }
             result
@@ -425,7 +425,7 @@ async fn process_sequential(
         if let Some(ref cb) = config.progress_callback {
             match &result.error {
                 None => cb.on_page_complete(page_num, total_pages, result.markdown.len()),
-                Some(e) => cb.on_page_error(page_num, total_pages, &e.to_string()),
+                Some(e) => cb.on_page_error(page_num, total_pages, e.to_string()),
             }
         }
 


### PR DESCRIPTION
## Fix: `on_page_error` `&str` → `String` — resolves HRTB Send issue (closes #8, closes #9)

### Problem

Calling `convert_from_bytes` (or any pipeline entrypoint) from an `#[async_trait]`
method that requires `Send` fails to compile:

```
error: implementation of `Send` is not general enough
  = note: `Send` would have to be implemented for `&str`
  = note: ...but `Send` is implemented for `&'0 str` for some specific lifetime `'0`
```

Root cause: `ConversionProgressCallback::on_page_error` accepted `error: &str`.
Inside `process_concurrent` the call site was
`cb.on_page_error(page_num, total_pages, &e.to_string())`, creating a temporary
`String` and borrowing it — producing a HRTB `for<'a> &'a str` that `async_trait`
cannot prove is `Send`.

### Fix

Change `on_page_error` to accept `error: String` (owned). Remove the `&` at both
call sites in `convert.rs` (`process_concurrent` and `process_sequential`).

### Files changed

| File | Change |
|------|--------|
| `src/progress.rs` | Trait signature + default impl + doc + unit tests |
| `src/convert.rs` | Two call sites: `&e.to_string()` → `e.to_string()` |
| `src/bin/pdf2md.rs` | `CliProgress::on_page_error` signature updated |
| `README.md` | Progress callback example updated |
| `CHANGELOG.md` | v0.4.2 entry added |
| `Cargo.toml` | Version bumped to 0.4.2 |
| `tests/e2e.rs` | Two new always-on regression tests added |

### Migration for users

```rust
// Before (0.4.1)
fn on_page_error(&self, page: usize, total: usize, error: &str) { … }

// After (0.4.2)
fn on_page_error(&self, page: usize, total: usize, error: String) { … }
```

### Tests

- `progress::tests::on_page_error_is_send_when_used_in_spawn` — moves `Arc<dyn ConversionProgressCallback>` into `tokio::spawn`, proving the future is `Send` at compile time.
- `progress::tests::on_page_error_receives_owned_string` — verifies the String is forwarded by value.
- `test_callback_send_in_tokio_spawn` (e2e.rs) — integration regression test.
- `test_noop_callback_is_send_sync` (e2e.rs) — static Send/Sync assertion.

All 49 tests pass (`cargo test --no-default-features --features cli`).
