### PR TITLE
feat: Mistral AI vision support + edgequake-llm 0.2.4 v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.3] — 2026-02-20
+
+### Added
+
+#### Mistral AI provider support (`pixtral-12b-2409`)
+
+- **Mistral as a first-class provider** via `edgequake-llm 0.2.4` (Mistral
+  added in 0.2.3; 0.2.4 is a docs/Python bindings bump with no Rust API
+  changes).
+
+  Use Mistral for PDF conversion by setting `MISTRAL_API_KEY`:
+  ```bash
+  export MISTRAL_API_KEY=your-key
+  pdf2md document.pdf -o output.md            # auto-selects pixtral-12b-2409
+  pdf2md --provider mistral document.pdf      # explicit, same default model
+  pdf2md --provider mistral --model pixtral-12b-2409 document.pdf
+  ```
+
+- **Vision-aware model default for Mistral**: `pixtral-12b-2409` is set as
+  the automatic default when `--provider mistral` is used (or
+  `MISTRAL_API_KEY` is the only key set) without an explicit `--model`. The
+  Mistral SDK default (`mistral-small-latest`) is **not** vision-capable and
+  would fail on every page; this prevents a silent misuse footgun.
+
+- **Auto-detection chain updated** in `resolve_provider`: after the OpenAI
+  preference block, `MISTRAL_API_KEY` is now checked explicitly so the
+  correct pixtral default is applied even when the factory's generic
+  `from_env()` would otherwise select an incompatible model.
+
+- **Mistral row** added to `--help` provider table and `ENVIRONMENT VARIABLES`
+  section in the CLI (`pdf2md --help`).
+
+#### Mistral models reference
+
+| Model | Context | Vision | Notes |
+|-------|---------|--------|-------|
+| `pixtral-12b-2409` | 128K | ✓ | Recommended for PDF conversion |
+| `mistral-small-latest` | 32K | ✗ | Text-only |
+| `mistral-large-latest` | 128K | ✗ | Text-only |
+
+#### New tests
+
+- `test_default_vision_model_mistral_variants` — unit test: all Mistral name
+  aliases map to `pixtral-12b-2409`
+- `test_default_vision_model_other_providers` — unit test: non-Mistral
+  providers fall back to `gpt-4.1-nano`
+- `test_mistral_config_builder_accepts_provider_name` — structural: config
+  builder accepts `provider_name = "mistral"` without errors
+- `test_mistral_pixtral_model_available` — structural: `pixtral-12b-2409`
+  appears in `MistralProvider::available_models()` catalogue
+- `test_pixtral_supports_vision` — structural: pixtral has the expected 128K
+  context window
+- `test_mistral_pdf_conversion` — gated e2e test (requires `E2E_ENABLED=1` +
+  `MISTRAL_API_KEY`): converts a single PDF page with pixtral
+
+### Changed
+
+#### Dependency bump: `edgequake-llm` 0.2.2 → 0.2.4
+
+- `0.2.3`: Added `MistralProvider` with pixtral-12b-2409 vision support
+- `0.2.4`: Documentation + `edgequake-litellm` Python bindings (no Rust API
+  changes)
+
+### Migration
+
+No breaking changes. Existing code and deployments continue to work
+unchanged. Mistral support is purely additive.
+
+---
+
 ## [0.4.2] — 2026-02-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.88"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -43,9 +43,10 @@ path = "src/lib.rs"
 pdfium-render  = { version = "0.8", features = ["pdfium_latest", "image_latest", "thread_safe"] }
 # Auto-download pdfium: zero-friction setup for end-users
 pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
-# v0.2.2 fixes OpenAIProvider::convert_messages() silently dropping ChatMessage.images.
-# We pin to "0.2.2" rather than "0.2" to guarantee the vision fix is present.
-edgequake-llm  = "0.2.2"
+# v0.2.3 adds MistralProvider with pixtral-12b-2409 vision support.
+# v0.2.4 adds edgequake-litellm Python bindings (docs bump; no Rust API changes).
+# We pin to "0.2.4" to guarantee Mistral + vision fixes are present.
+edgequake-llm  = "0.2.4"
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Inspired by [pyzerox](https://github.com/getomni-ai/zerox), rebuilt in Rust for 
 
 ## Features
 
-- **Multi-provider** — OpenAI, Anthropic, Google Gemini, Azure, Ollama, or any OpenAI-compatible endpoint
+- **Multi-provider** — OpenAI, Anthropic, Google Gemini, Mistral AI, Azure, Ollama, or any OpenAI-compatible endpoint
 - **Fast** — concurrent page processing with configurable parallelism
 - **Accurate** — 10-rule post-processing pipeline fixes tables, removes hallucinations, normalises output
 - **Flexible** — page selection, fidelity tiers, custom system prompts, streaming API
@@ -46,6 +46,8 @@ export OPENAI_API_KEY="sk-..."    # OpenAI (recommended)
 export ANTHROPIC_API_KEY="sk-ant-..."  # Anthropic
 # or
 export GEMINI_API_KEY="AI..."          # Google Gemini
+# or
+export MISTRAL_API_KEY="..."           # Mistral AI (uses pixtral-12b-2409)
 ```
 
 ### 2. Build & run
@@ -106,6 +108,12 @@ pdf2md --json --metadata document.pdf > output.json
 # Use Anthropic
 pdf2md --provider anthropic --model claude-sonnet-4-20250514 document.pdf
 
+# Use Mistral (pixtral-12b-2409 auto-selected as vision model)
+export MISTRAL_API_KEY=your-key
+pdf2md document.pdf
+# or explcitly:
+pdf2md --provider mistral --model pixtral-12b-2409 document.pdf
+
 # Use local Ollama
 pdf2md --provider ollama --model llava document.pdf
 ```
@@ -125,6 +133,7 @@ See [docs/examples.md](docs/examples.md) for more usage patterns.
 | **Anthropic** | claude-haiku-4-20250514 | $0.80 | $4.00 | ✓ |
 | **Gemini** | gemini-2.0-flash | $0.10 | $0.40 | ✓ |
 | **Gemini** | gemini-2.5-pro | $1.25 | $10.00 | ✓ |
+| **Mistral** | pixtral-12b-2409 | $0.15 | $0.15 | ✓ |
 | **Ollama** | llava, llama3.2-vision | free | free | ✓ |
 
 **Cost estimate:** A 50-page document costs ~$0.02 with gpt-4.1-nano, ~$0.09 with gpt-4.1-mini.
@@ -255,7 +264,7 @@ Provider resolution order (highest-to-lowest priority):
 1. `config.provider` — explicit `Arc<dyn LLMProvider>` injection
 2. `config.provider_name` + `config.model` — named provider
 3. `EDGEQUAKE_LLM_PROVIDER` + `EDGEQUAKE_MODEL` environment variables
-4. Auto-detect from API key env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …)
+4. Auto-detect from API key env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, …)
 
 Also available: streaming API (`convert_stream`, `convert_stream_from_bytes`), sync wrapper (`convert_sync`), metadata inspection (`inspect`).
 

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -199,6 +199,10 @@ const AFTER_HELP: &str = r#"EXAMPLES:
   # Use a specific model
   pdf2md --model gpt-4.1 --provider openai document.pdf
 
+  # Use Mistral (pixtral-12b-2409 auto-selected as the vision model)
+  export MISTRAL_API_KEY=your-key
+  pdf2md document.pdf
+
   # Convert from URL
   pdf2md https://arxiv.org/pdf/1706.03762 -o attention.md
 
@@ -222,6 +226,7 @@ SUPPORTED PROVIDERS & MODELS:
   anthropic    claude-haiku-4-20250514          $0.80       $4.00        ✓
   gemini       gemini-2.0-flash       $0.10       $0.40        ✓
   gemini       gemini-2.5-pro         $1.25       $10.00       ✓
+  mistral      pixtral-12b-2409       $0.15       $0.15        ✓
   ollama       llava, llama3.2-vision free        free         ✓
 
 COST ESTIMATE (50-page document @ 150 DPI):
@@ -237,7 +242,8 @@ ENVIRONMENT VARIABLES:
   OPENAI_API_KEY          OpenAI API key
   ANTHROPIC_API_KEY       Anthropic API key
   GEMINI_API_KEY          Google Gemini API key
-  EDGEQUAKE_LLM_PROVIDER  Override provider (openai, anthropic, gemini, ollama)
+  MISTRAL_API_KEY         Mistral AI API key (uses pixtral-12b-2409 for vision)
+  EDGEQUAKE_LLM_PROVIDER  Override provider (openai, anthropic, gemini, mistral, ollama)
   EDGEQUAKE_MODEL         Override model ID
   PDFIUM_LIB_PATH         Path to an existing libpdfium — skips auto-download
   PDFIUM_AUTO_CACHE_DIR   Override the default pdfium cache directory


### PR DESCRIPTION
## Summary

Adds Mistral AI as a first-class PDF-to-Markdown vision provider by bumping `edgequake-llm` to 0.2.4.

### Key Changes

**`edgequake-llm` 0.2.2 → 0.2.4**
- 0.2.3 added `MistralProvider` with pixtral-12b-2409 (128K context, vision-capable)
- 0.2.4 is a docs/Python-bindings bump with no Rust API changes

**Vision-aware model defaults** (`src/convert.rs`)
- New `default_vision_model_for_provider()` helper: `mistral` → `pixtral-12b-2409`, others → `gpt-4.1-nano`
- Fixes: without this, `--provider mistral` would silently use `mistral-small-latest` (not vision-capable) and fail on every page
- Mistral explicit auto-detect block: when only `MISTRAL_API_KEY` is set, pixtral-12b-2409 is used automatically

**CLI + docs**
- Provider table in `--help` now includes Mistral/pixtral row
- `MISTRAL_API_KEY` documented in env-vars section and README
- README providers table, examples, and API key section updated

### Tests
- 2 unit tests: `default_vision_model_for_provider` Mistral variants + fallback
- 3 always-run structural tests: config-builder, available-models catalogue, 128K context assertion
- 1 gated e2e test: `E2E_ENABLED=1 MISTRAL_API_KEY=... cargo test`

### All tests pass
- 36 lib unit tests
- 19 integration tests
- 7 doc tests
- fmt + clippy clean

### Usage
```bash
export MISTRAL_API_KEY=your-key
pdf2md document.pdf                              # auto-selects pixtral
pdf2md --provider mistral document.pdf          # explicit
pdf2md --provider mistral --model pixtral-12b-2409 document.pdf
```
