### PR TITLE
fix: bump edgequake-llm 0.2.5 — fix gpt-4.1-nano max_completion_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.4] — 2026-02-20
+
+### Fixed
+
+- **Issue #13 — `gpt-4.1-nano` (and o1/o3/o4-mini) rejected all PDF vision
+  requests** with `400 Bad Request: 'max_tokens' is not supported with this
+  model. Use 'max_completion_tokens' instead.`
+
+  Root cause: `edgequake-llm ≤ 0.2.4` passed `max_tokens` in the OpenAI
+  request body for every model. The gpt-4.1 family and o-series only accept
+  `max_completion_tokens`.
+
+  Fix: bump dependency `edgequake-llm` `0.2.4` → `0.2.5`. The 0.2.5 release
+  upgrades `async-openai` from 0.24 → 0.33, which exposes
+  `max_completion_tokens` natively and uses it unconditionally (valid for all
+  current chat models).
+
+### Changed
+
+- **`edgequake-llm` dependency bumped** `0.2.4` → `0.2.5`.
+  - 0.2.5: async-openai 0.24 → 0.33 upgrade; `max_tokens` → `max_completion_tokens`
+    routing; cache-hit + reasoning-token extraction; 23 new tests.
+
+### Tests
+
+- `test_issue13_max_tokens_config_builds_for_gpt41_nano` — always-run: verifies
+  `ConversionConfig::builder().max_tokens(2048)` round-trips the field without
+  panic (compile-time + config-layer regression guard).
+- `test_gpt41_nano_max_completion_tokens_regression` — gated e2e test (requires
+  `E2E_ENABLED=1` and `OPENAI_API_KEY`): converts a PDF page with `gpt-4.1-nano`
+  and `max_tokens=2048`; fails if the `400 Bad Request` from issue #13 recurs.
+
+---
+
 ## [0.4.3] — 2026-02-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.88"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -45,8 +45,10 @@ pdfium-render  = { version = "0.8", features = ["pdfium_latest", "image_latest",
 pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 # v0.2.3 adds MistralProvider with pixtral-12b-2409 vision support.
 # v0.2.4 adds edgequake-litellm Python bindings (docs bump; no Rust API changes).
-# We pin to "0.2.4" to guarantee Mistral + vision fixes are present.
-edgequake-llm  = "0.2.4"
+# v0.2.5 fixes issue #13: max_completion_tokens for gpt-4.1-nano / o-series
+#         (async-openai upgraded 0.24→0.33; max_tokens now routes correctly).
+# We pin to "0.2.5" to guarantee gpt-4.1-nano vision extraction works.
+edgequake-llm  = "0.2.5"
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"


### PR DESCRIPTION
## Summary

Fixes gpt-4.1-nano (and o1/o3/o4-mini) vision extraction failures by bumping
`edgequake-llm` from `0.2.4` → `0.2.5`.

Closes / addresses: edgequake-llm issue #13 — _"Unsupported parameter: 'max_tokens'
is not supported with this model. Use 'max_completion_tokens' instead."_

---

## Root Cause

`edgequake-llm ≤ 0.2.4` used `async-openai 0.24`, which only exposes `max_tokens`
on `CreateChatCompletionRequest`. Models in the gpt-4.1 and o-series families reject
`max_tokens` outright, returning a `400 Bad Request` on every vision page call.

## Fix

`edgequake-llm 0.2.5` upgrades `async-openai` from `0.24 → 0.33`. The 0.33 API
exposes `max_completion_tokens` natively, and `OpenAIProvider::chat()` now calls
`.max_completion_tokens()` unconditionally—accepted by all current OpenAI chat
models, including gpt-4.1-nano, gpt-4.1-mini, o1, o3-mini, and o4-mini.

No changes to the `edgequake-pdf2md` public API or `CompletionOptions` struct are
required; the fix is entirely within `edgequake-llm`.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `edgequake-llm "0.2.4"` → `"0.2.5"`; version `0.4.3` → `0.4.4` |
| `tests/e2e.rs` | + `test_issue13_max_tokens_config_builds_for_gpt41_nano` (always-run) |
| `tests/e2e.rs` | + `test_gpt41_nano_max_completion_tokens_regression` (gated e2e) |
| `CHANGELOG.md` | Added `[0.4.4]` entry |

## Tests

- **36** existing lib unit tests — all pass ✅
- **21** integration tests (19 existing + 2 new) — all pass ✅  
- **7** doc tests — all pass ✅
- `fmt` clean ✅ · `clippy -D warnings` clean ✅

### New tests gating the fix

| Test | Gate | Purpose |
|------|------|---------|
| `test_issue13_max_tokens_config_builds_for_gpt41_nano` | always-run | Verify `max_tokens` round-trips through `ConversionConfig::builder()` |
| `test_gpt41_nano_max_completion_tokens_regression` | `E2E_ENABLED=1` + `OPENAI_API_KEY` | Actual API call with `gpt-4.1-nano + max_tokens=2048`; fails if issue #13 recurs |
