### PR TITLE
feat: bump edgequake-llm to 0.2.7, edgequake-litellm 0.1.3, release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.6] — 2026-02-22
+
+### Changed
+
+- **`edgequake-llm` dependency bumped `0.2.6` → `0.2.7`.**
+  - 0.2.7 rewrites the Azure OpenAI provider to use the `async-openai`
+    `AzureConfig` trait instead of hand-rolled HTTP, eliminating ~400 lines of
+    bespoke request building.
+  - New `AzureOpenAIProvider::from_env_contentgen()` reads the enterprise
+    `AZURE_OPENAI_CONTENTGEN_*` naming scheme; `from_env_auto()` tries
+    CONTENTGEN first and falls back to standard `AZURE_OPENAI_*` transparently.
+  - `AzureOpenAIProvider::with_deployment(name)` — builder method for runtime
+    deployment switching (mirrors `with_embedding_deployment()`).
+  - `ImageData::from_url(url)`, `is_url() -> bool`, `to_api_url() -> String`
+    URL-native helpers: OpenAI and Azure providers now pass URL images directly
+    to the API without unnecessary base64 wrapping.
+  - Content-filter guardrail: responses with `finish_reason = "content_filter"`
+    are surfaced as `LlmError::ApiError` with a descriptive message.
+  - `ProviderFactory::from_env()` auto-detects Azure when
+    `AZURE_OPENAI_CONTENTGEN_API_KEY` (or `AZURE_OPENAI_API_KEY`) plus endpoint
+    are set; `ProviderType::AzureOpenAI` variant recognised from `"azure"`,
+    `"azure-openai"`, `"azure_openai"`, `"azureopenai"` (case-insensitive).
+  - 25-test Azure E2E suite covering chat, JSON mode, streaming, tool calling,
+    vision (base64 and URL images, detail levels), embeddings, and
+    content-filter scenarios.
+  - `OpenAIProvider::from_env()` — new constructor with dotenvy (.env file)
+    support; `supports_json_mode()` extended to cover `gpt-5` prefix.
+
+- **`edgequake-litellm` Python package updated `0.1.2` → `0.1.3`.**
+  - `"azure"` provider added to `list_providers()`.
+  - Callers can now pass `model="azure/<deployment-name>"` to route to Azure
+    OpenAI from Python.
+
+### Added
+
+- **`docs/providers.md` Azure OpenAI section** expanded: 3-constructor table
+  (`from_env`, `from_env_contentgen`, `from_env_auto`), CONTENTGEN env-var
+  reference, runtime deployment switching, vision support note, and reliable
+  Azure sample image URLs.
+
+---
+
 ## [0.4.5] — 2026-02-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.88"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -49,8 +49,13 @@ pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 #         (async-openai upgraded 0.24→0.33; max_tokens now routes correctly).
 # v0.2.6 fixes vision image forwarding in Ollama, LM Studio, and OpenRouter
 #         providers (Issue #15 — images were silently dropped).
-# We pin to "0.2.6" to guarantee vision works correctly across all providers.
-edgequake-llm  = "0.2.6"
+# v0.2.7 rewrites Azure OpenAI to use the async-openai AzureConfig type,
+#         adds ImageData::from_url / is_url / to_api_url URL-native helpers,
+#         adds content-filter guardrail (finish_reason="content_filter" →
+#         LlmError::ApiError), and adds ProviderFactory Azure auto-detection.
+#         edgequake-litellm 0.1.3 adds azure provider to list_providers().
+# We pin to "0.2.7" to gain native Azure vision + URL image pass-through.
+edgequake-llm  = "0.2.7"
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"

--- a/README.md
+++ b/README.md
@@ -328,10 +328,12 @@ make inspect-all    # Inspect test PDFs
 | Crate | Purpose |
 |-------|---------|
 | [pdfium-render](https://crates.io/crates/pdfium-render) | PDF rasterisation via Google's pdfium C++ library |
-| [edgequake-llm](https://crates.io/crates/edgequake-llm) | Multi-provider LLM abstraction (OpenAI, Anthropic, Gemini, etc.) |
+| [edgequake-llm](https://crates.io/crates/edgequake-llm) | Multi-provider LLM abstraction (OpenAI, Anthropic, Gemini, Azure, Ollama, etc.) — v0.2.7+ |
 | [tokio](https://crates.io/crates/tokio) | Async runtime |
 | [image](https://crates.io/crates/image) | Image encoding (PNG/JPEG) |
 | [clap](https://crates.io/crates/clap) | CLI argument parsing |
+
+> **Python users:** `edgequake-litellm` v0.1.3 ([PyPI](https://pypi.org/project/edgequake-litellm/)) is a drop-in LiteLLM replacement backed by `edgequake-llm`. It supports Azure OpenAI via `model="azure/<deployment>"`.
 
 ## External References
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Supported Providers & Models
 
-`edgequake-pdf2md` works with any Vision Language Model (VLM) supported by [edgequake-llm](https://crates.io/crates/edgequake-llm).
+`edgequake-pdf2md` works with any Vision Language Model (VLM) supported by [edgequake-llm](https://crates.io/crates/edgequake-llm) (v0.2.7+).
 
 ## Provider Overview
 
@@ -9,7 +9,7 @@
 | **OpenAI** | `OPENAI_API_KEY` | gpt-4.1-nano, gpt-4.1-mini, gpt-4.1, gpt-4o | Default provider, best cost/quality |
 | **Anthropic** | `ANTHROPIC_API_KEY` | claude-sonnet-4-20250514, claude-haiku-4-20250514 | High accuracy for complex layouts |
 | **Google Gemini** | `GEMINI_API_KEY` | gemini-2.0-flash, gemini-2.5-pro | Large context window |
-| **Azure OpenAI** | `AZURE_OPENAI_API_KEY` | gpt-4o (deployed) | Enterprise compliance |
+| **Azure OpenAI** | `AZURE_OPENAI_API_KEY` | gpt-4o (deployed) | Enterprise compliance, native vision |
 | **Ollama** | (local) | llava, llama3.2-vision | Free, runs locally |
 | **OpenAI-compatible** | `OPENAI_API_KEY` + custom base URL | Any vision model | vLLM, LiteLLM, Together AI, etc. |
 
@@ -92,11 +92,74 @@ export GEMINI_API_KEY="AI..."
 pdf2md --provider gemini --model gemini-2.0-flash document.pdf
 ```
 
+### Azure OpenAI
+
+As of `edgequake-llm` v0.2.7, the Azure OpenAI provider is a full native rewrite using the
+`async-openai` `AzureConfig` trait — no hand-rolled HTTP, full vision support.
+
+#### Constructor options
+
+| Constructor | When to use |
+|------------|-------------|
+| `from_env()` | Standard `AZURE_OPENAI_*` env vars |
+| `from_env_contentgen()` | Enterprise `AZURE_OPENAI_CONTENTGEN_*` naming scheme |
+| `from_env_auto()` | Tries CONTENTGEN first, falls back to standard automatically |
+
+#### Standard env vars
+
+```bash
+export AZURE_OPENAI_API_KEY="..."
+export AZURE_OPENAI_ENDPOINT="https://<resource>.openai.azure.com"
+export AZURE_OPENAI_DEPLOYMENT_NAME="gpt-4o"        # chat deployment
+export AZURE_OPENAI_API_VERSION="2024-02-01"
+```
+
+#### Enterprise (ContentGen) env vars
+
+```bash
+export AZURE_OPENAI_CONTENTGEN_API_KEY="..."
+export AZURE_OPENAI_CONTENTGEN_API_ENDPOINT="https://<resource>.openai.azure.com"
+export AZURE_OPENAI_CONTENTGEN_MODEL_DEPLOYMENT="gpt-4o"
+export AZURE_OPENAI_CONTENTGEN_API_VERSION="2024-02-01"
+```
+
+#### CLI usage
+
+```bash
+# Standard AZURE_OPENAI_* vars
+pdf2md --provider azure --model gpt-4o document.pdf
+
+# URL images are passed to Azure API directly (no base64 re-encoding)
+pdf2md --provider azure --model gpt-4o https://example.com/document.pdf
+```
+
+> **Note:** `ProviderFactory::from_env()` in v0.2.7 auto-detects Azure when
+> `AZURE_OPENAI_CONTENTGEN_API_KEY` or `AZURE_OPENAI_API_KEY` plus endpoint
+> are set — no `--provider azure` flag needed.
+
 ### Ollama (Local)
 
 ```bash
 ollama pull llava
 pdf2md --provider ollama --model llava document.pdf
+```
+
+### edgequake-litellm (Python)
+
+`edgequake-litellm` v0.1.3 adds Azure routing support:
+
+```python
+import edgequake_litellm as litellm
+
+# Route to Azure OpenAI
+response = litellm.completion(
+    model="azure/gpt-4o",          # azure/<deployment-name>
+    messages=[{"role": "user", "content": "Summarise this PDF page."}],
+)
+print(response.choices[0].message.content)
+
+# List all supported providers (includes "azure" in v0.1.3)
+print(litellm.list_providers())
 ```
 
 ### Auto-Detection


### PR DESCRIPTION
- edgequake-llm 0.2.7: Azure OpenAI official-crate rewrite (async-openai
  AzureConfig), from_env_contentgen/from_env_auto constructors, with_deployment
  builder, ImageData URL-native helpers (from_url/is_url/to_api_url),
  content-filter guardrail, ProviderFactory Azure auto-detection, 25-test
  Azure E2E suite, OpenAIProvider::from_env with dotenvy support
- edgequake-litellm 0.1.3: azure provider in list_providers(), model='azure/<d>'
  routing support
- docs/providers.md: Azure OpenAI section expanded with 3-constructor table,
  CONTENTGEN env vars, runtime deployment switching, litellm 0.1.3 example
- README.md: Dependencies table updated; edgequake-litellm PyPI callout added
