### PR TITLE
feat: bump edgequake-llm 0.3.0 → 0.5.1, release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.0] — 2026-04-08
+
+### Changed
+
+- **Bump `edgequake-llm` dependency from `0.3.0` to `0.5.1`** — picks up all
+  provider additions and fixes released between the two versions:
+  - Azure OpenAI provider (`AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`)
+  - Mistral AI provider (`MISTRAL_API_KEY`)
+  - Google Vertex AI as a distinct provider type (`GOOGLE_CLOUD_PROJECT`)
+  - xAI / Grok 4.20 improvements and timeout fixes
+  - Image generation API (`ImageGenProvider` trait, Gemini/VertexAI/FAL backends)
+  - Streaming usage propagation fixes (terminal chunk handling)
+  - Security dependency updates
+
+  All existing call sites (`ProviderFactory::create_llm_provider`,
+  `ProviderFactory::from_env`, `LLMProvider`, `ChatMessage`, `CompletionOptions`,
+  `ImageData`) are unchanged — this is a backward-compatible bump.
+
+---
+
 ## [0.7.0] — 2026-06-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.91"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -48,7 +48,7 @@ pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 #         auto-resolution, and fixes reasoning model false positives for
 #         Qwen3-VL / Qwen3-VL-Embedding (Issue #19).
 #         Default model changed to amazon.nova-lite-v1:0.
-edgequake-llm  = { version = "0.3.0", features = ["bedrock"] }
+edgequake-llm  = { version = "0.5.1", features = ["bedrock"] }
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"


### PR DESCRIPTION
## Summary

Bumps the `edgequake-llm` dependency from `0.3.0` to `0.5.1` and releases the library as **v0.8.0**.

### What's new in edgequake-llm 0.5.1 (vs 0.3.0)

| Version | Highlights |
|---------|-----------|
| 0.3.0 | AWS Bedrock native embedding, 30+ model coverage |
| 0.2.9 | AWS Bedrock Converse API provider |
| 0.2.8 | Azure OpenAI provider (async-openai rewrite) |
| 0.4.0 | VertexAI as distinct `ProviderType::VertexAI` (separate from Gemini) |
| 0.5.0 | Image generation API (`ImageGenProvider` trait), xAI Grok 4.20 |
| 0.5.1 | Streaming usage propagation fixes, security dep updates |

### Impact on edgequake-pdf2md

- **No code changes required.** All call sites (`ProviderFactory::create_llm_provider`, `from_env`, `LLMProvider`, `ChatMessage`, `CompletionOptions`, `ImageData`) have identical signatures in 0.5.1.
- Build verified: `cargo build --lib` completes cleanly against 0.5.1.

### Why

The downstream **edgequake** project upgraded `edgequake-llm` to 0.5.1 for new provider support (Azure, Mistral, VertexAI). Without this bump, `edgequake-pdf2md` and `edgequake` pull two different versions of `edgequake-llm` into the same binary, causing a trait mismatch compile error (`E0308`).

## Merge instructions

Please **squash-merge** this PR and immediately publish `v0.8.0` to crates.io so `edgequake` can update its pin (`edgequake-pdf2md = "=0.7.0"` → `"=0.8.0"`).