### PR TITLE
feat: bump edgequake-llm 0.6.0 → 0.6.18, release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.0] — 2026-05-06
+
+### Changed
+
+- **Bump `edgequake-llm` dependency from `0.6.0` to `0.6.18`** — picks up all
+  provider additions and fixes released between the two versions:
+  - NVIDIA NIM provider (`NVIDIA_API_KEY`) — added in v0.6.14
+  - Mistral: `max_batch_size()` set to 512 preventing HTTP 400 code 3210 — v0.6.15
+  - `with_extra_headers()` builder on `OpenAICompatibleProvider` and `MistralProvider` — v0.6.16
+  - `with_extra_headers()` builder on `AnthropicProvider`, `GeminiProvider`, `NvidiaProvider` — v0.6.17
+  - Mistral embedding: defense-in-depth `embed_batch_http` guard — v0.6.18
+
+### Added (CLI)
+
+- **Short flag `-m` for `--model`** — `pdf2md -m gpt-4.1-nano` now works alongside the long form.
+- **Auto-detect provider from model slash-prefix** — if `--provider` is not given and
+  the model ID contains a `/`, the prefix is used as the provider name. E.g. `pdf2md -m anthropic/claude-sonnet-4-20250514` automatically selects the `anthropic` provider.
+- **Anthropic model shorthand mapping** — `claude-sonnet-4-6`, `claude-sonnet-4.6`, and
+  `claude-sonnet-latest` are transparently mapped to the canonical `claude-sonnet-4-20250514` model ID.
+
+---
+
 ## [0.8.0] — 2026-04-08
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.91"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -48,7 +48,7 @@ pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 #         auto-resolution, and fixes reasoning model false positives for
 #         Qwen3-VL / Qwen3-VL-Embedding (Issue #19).
 #         Default model changed to amazon.nova-lite-v1:0.
-edgequake-llm  = { version = "0.6.0", features = ["bedrock"] }
+edgequake-llm  = { version = "0.6.18", features = ["bedrock"] }
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -312,13 +312,14 @@ struct Cli {
     #[arg(short, long, env = "PDF2MD_OUTPUT")]
     output: Option<PathBuf>,
 
-    /// LLM model ID (e.g. amazon.nova-lite-v1:0, gpt-4.1-nano, claude-sonnet-4-20250514).
-    #[arg(
-        long,
-        env = "EDGEQUAKE_MODEL",
-        long_help = "Vision LLM model to use. Default: amazon.nova-lite-v1:0 ($0.06/$0.24 per 1M tokens).\n\
-          Popular choices: gpt-4.1-nano ($0.10/$0.40), gpt-4.1-mini ($0.40/$1.60), claude-sonnet-4-20250514 ($3/$15)."
-    )]
+        /// LLM model ID (e.g. amazon.nova-lite-v1:0, gpt-4.1-nano, claude-sonnet-4-20250514).
+        #[arg(
+                short = 'm',
+                long,
+                env = "EDGEQUAKE_MODEL",
+                long_help = "Vision LLM model to use. Default: amazon.nova-lite-v1:0 ($0.06/$0.24 per 1M tokens).\n\
+                    Popular choices: gpt-4.1-nano ($0.10/$0.40), gpt-4.1-mini ($0.40/$1.60), claude-sonnet-4-20250514 ($3/$15)."
+        )]
     model: Option<String>,
 
     /// LLM provider: bedrock, openai, anthropic, gemini, ollama, azure.
@@ -698,9 +699,42 @@ async fn build_config(cli: &Cli, progress: Option<ProgressCallback>) -> Result<C
 
     let mut config = builder.build().context("Invalid configuration")?;
 
+    // If the user passed a model like "anthropic/claude-sonnet-4-6" and did
+    // not explicitly set `--provider`, treat the prefix as the provider
+    // and the suffix as the model ID. This prevents accidental provider
+    // selection based on unrelated env vars (e.g. OPENAI_API_KEY present).
+    let mut model_val = cli.model.clone();
+    let mut provider_val = cli.provider.clone();
+    if provider_val.is_none() {
+        if let Some(ref m) = model_val {
+            if let Some((prov, mdl)) = m.split_once('/') {
+                provider_val = Some(prov.to_string());
+                model_val = Some(mdl.to_string());
+            }
+        }
+    }
+
     // Apply fields the builder doesn't have setters for (or that need special handling)
-    config.model = cli.model.clone();
-    config.provider_name = cli.provider.clone();
+    // Map a few common shorthand variants to the canonical Anthropic model IDs.
+    if let Some(ref prov) = provider_val {
+        if prov == "anthropic" {
+            if let Some(ref m) = model_val {
+                let canonical = match m.as_str() {
+                    "claude-sonnet-4-6" | "claude-sonnet-4.6" | "claude-sonnet-latest" => {
+                        Some("claude-sonnet-4-20250514".to_string())
+                    }
+                    // keep other values unchanged
+                    _ => None,
+                };
+                if let Some(c) = canonical {
+                    model_val = Some(c);
+                }
+            }
+        }
+    }
+
+    config.model = model_val;
+    config.provider_name = provider_val;
     config.password = cli.password.clone();
     config.system_prompt = system_prompt;
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -858,6 +858,59 @@ async fn test_mistral_pdf_conversion() {
     );
 }
 
+/// Gated e2e: convert one PDF page using Anthropic Claude Sonnet 4.6.
+///
+/// Requirements:
+/// - `E2E_ENABLED=1`
+/// - Anthropic credentials set: `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`
+///
+/// Run:
+///   E2E_ENABLED=1 ANTHROPIC_API_KEY=... cargo test --test e2e test_anthropic_claude_sonnet -- --nocapture
+#[tokio::test]
+async fn test_anthropic_claude_sonnet() {
+    if std::env::var("E2E_ENABLED").is_err() {
+        println!("SKIP — set E2E_ENABLED=1 and Anthropic credentials to run");
+        return;
+    }
+    // Accept either ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN per env conventions
+    if std::env::var("ANTHROPIC_API_KEY").is_err() && std::env::var("ANTHROPIC_AUTH_TOKEN").is_err() {
+        println!("SKIP — Anthropic credentials not set (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)");
+        return;
+    }
+
+    let pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_cases")
+        .join("neuroscience_textbook.pdf");
+    if !pdf_path.exists() {
+        println!("SKIP — test_cases/neuroscience_textbook.pdf not found. Run: make download-test-pdfs");
+        return;
+    }
+
+    let config = ConversionConfig::builder()
+        .dpi(150)
+        .concurrency(1)
+        .pages(PageSelection::Single(1))
+        .fidelity(FidelityTier::Tier2)
+        .max_retries(2)
+        .max_tokens(4096)
+        .build()
+        .expect("config must build");
+
+    let mut cfg = config;
+    cfg.provider_name = Some("anthropic".to_string());
+    cfg.model = Some("claude-sonnet-4.6".to_string());
+
+    let result = convert(&pdf_path.to_string_lossy(), &cfg)
+        .await
+        .expect("Anthropic Claude Sonnet conversion must succeed");
+
+    assert!(!result.markdown.trim().is_empty(), "Anthropic conversion must produce non-empty Markdown");
+    assert_eq!(result.stats.processed_pages, 1);
+    assert_eq!(result.stats.failed_pages, 0);
+
+    println!("[anthropic] output ({} chars):\n{}", result.markdown.len(), result.markdown);
+}
+
 // ── Ollama provider e2e tests ─────────────────────────────────────────────────
 
 /// Helper: check if Ollama is reachable at the configured host.


### PR DESCRIPTION
## Summary

- Bump `edgequake-llm` from 0.6.0 → 0.6.18
  - NVIDIA NIM provider (v0.6.14)
  - Mistral `max_batch_size()` = 512 fix (v0.6.15)
  - `with_extra_headers()` on OpenAI-compat & Mistral providers (v0.6.16)
  - `with_extra_headers()` on Anthropic, Gemini, NVIDIA providers (v0.6.17)
  - Mistral embed batch HTTP defense-in-depth (v0.6.18)
- CLI: add short `-m` flag for `--model`
- CLI: auto-detect provider from model slash-prefix (e.g. `anthropic/claude-sonnet-4-20250514`)
- CLI: map Anthropic shorthands to canonical model IDs
- Add gated e2e test for Anthropic Claude Sonnet 4.6
- Bump version 0.8.1 → 0.9.0

## Tests

```
cargo test --lib  # 79 tests pass
```