### PR TITLE
feat: bump edgequake-llm 0.6.18 → 0.6.20, release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] — 2026-05-06
+
+### Changed
+
+- **Bump `edgequake-llm` from `0.6.18` → `0.6.20`** — critical embedding fix:
+  - v0.6.20: `MISTRAL_EMBED_MAX_BATCH_SIZE` corrected from 512 to **256** (true Mistral API hard limit). Sending >256 inputs per request triggered HTTP 400 code 3210 "Too many inputs in request", causing large-document ingestion failures permanently.
+  - v0.6.19: `ProviderFactory::create_llm_provider_with_headers()` — B2B header propagation for multi-tenant deployments.
+
+---
+
 ## [0.9.0] — 2026-05-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.91"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -48,7 +48,7 @@ pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 #         auto-resolution, and fixes reasoning model false positives for
 #         Qwen3-VL / Qwen3-VL-Embedding (Issue #19).
 #         Default model changed to amazon.nova-lite-v1:0.
-edgequake-llm  = { version = "0.6.18", features = ["bedrock"] }
+edgequake-llm  = { version = "0.6.20", features = ["bedrock"] }
 tokio          = { version = "1", features = ["full"] }
 futures        = "0.3"
 tokio-stream   = "0.1"

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -312,14 +312,14 @@ struct Cli {
     #[arg(short, long, env = "PDF2MD_OUTPUT")]
     output: Option<PathBuf>,
 
-        /// LLM model ID (e.g. amazon.nova-lite-v1:0, gpt-4.1-nano, claude-sonnet-4-20250514).
-        #[arg(
-                short = 'm',
-                long,
-                env = "EDGEQUAKE_MODEL",
-                long_help = "Vision LLM model to use. Default: amazon.nova-lite-v1:0 ($0.06/$0.24 per 1M tokens).\n\
+    /// LLM model ID (e.g. amazon.nova-lite-v1:0, gpt-4.1-nano, claude-sonnet-4-20250514).
+    #[arg(
+        short = 'm',
+        long,
+        env = "EDGEQUAKE_MODEL",
+        long_help = "Vision LLM model to use. Default: amazon.nova-lite-v1:0 ($0.06/$0.24 per 1M tokens).\n\
                     Popular choices: gpt-4.1-nano ($0.10/$0.40), gpt-4.1-mini ($0.40/$1.60), claude-sonnet-4-20250514 ($3/$15)."
-        )]
+    )]
     model: Option<String>,
 
     /// LLM provider: bedrock, openai, anthropic, gemini, ollama, azure.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -873,8 +873,11 @@ async fn test_anthropic_claude_sonnet() {
         return;
     }
     // Accept either ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN per env conventions
-    if std::env::var("ANTHROPIC_API_KEY").is_err() && std::env::var("ANTHROPIC_AUTH_TOKEN").is_err() {
-        println!("SKIP — Anthropic credentials not set (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)");
+    if std::env::var("ANTHROPIC_API_KEY").is_err() && std::env::var("ANTHROPIC_AUTH_TOKEN").is_err()
+    {
+        println!(
+            "SKIP — Anthropic credentials not set (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)"
+        );
         return;
     }
 
@@ -882,7 +885,9 @@ async fn test_anthropic_claude_sonnet() {
         .join("test_cases")
         .join("neuroscience_textbook.pdf");
     if !pdf_path.exists() {
-        println!("SKIP — test_cases/neuroscience_textbook.pdf not found. Run: make download-test-pdfs");
+        println!(
+            "SKIP — test_cases/neuroscience_textbook.pdf not found. Run: make download-test-pdfs"
+        );
         return;
     }
 
@@ -904,11 +909,18 @@ async fn test_anthropic_claude_sonnet() {
         .await
         .expect("Anthropic Claude Sonnet conversion must succeed");
 
-    assert!(!result.markdown.trim().is_empty(), "Anthropic conversion must produce non-empty Markdown");
+    assert!(
+        !result.markdown.trim().is_empty(),
+        "Anthropic conversion must produce non-empty Markdown"
+    );
     assert_eq!(result.stats.processed_pages, 1);
     assert_eq!(result.stats.failed_pages, 0);
 
-    println!("[anthropic] output ({} chars):\n{}", result.markdown.len(), result.markdown);
+    println!(
+        "[anthropic] output ({} chars):\n{}",
+        result.markdown.len(),
+        result.markdown
+    );
 }
 
 // ── Ollama provider e2e tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

- Bump `edgequake-llm` from `0.6.18` to `0.6.20`
- v0.6.20: `MISTRAL_EMBED_MAX_BATCH_SIZE` corrected 512→256 (true Mistral API hard limit; >256 triggered HTTP 400 code 3210)
- v0.6.19: `ProviderFactory::create_llm_provider_with_headers()` — B2B header propagation
- style: rustfmt formatting in src/bin/pdf2md.rs and tests/e2e.rs

## Testing
- ✅ `cargo fmt --check` passes
- ✅ `cargo clippy -D warnings` passes
- ✅ `cargo doc --no-deps -D warnings` passes