### PR TITLE
fix(pdfium): use OnceCell singleton to prevent SIGBUS on Linux, release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.2] — 2026-05-06
+
+### Fixed
+
+- **SIGBUS at process exit on Linux** — `Pdfium` instances created in
+  `spawn_blocking` contexts were dropped at task completion, triggering
+  `FPDF_DestroyLibrary` + `dlclose`.  On Linux, this unmaps the pdfium code
+  pages; any atexit/TLS destructor that later references a pdfium function
+  pointer causes SIGBUS.  Fixed by converting `get_pdfium()` from returning an
+  owned `Pdfium` value to returning a `&'static Pdfium` backed by a
+  `once_cell::sync::OnceCell` singleton.  `FPDF_InitLibrary` is now called
+  exactly once and `FPDF_DestroyLibrary` is never called during the process
+  lifetime, matching pdfium's documented usage contract.
+
+### Changed
+
+- **`pdfium-render` feature flag**: `thread_safe` → `sync`** — the `sync`
+  feature is a superset of `thread_safe` that additionally marks `Pdfium` as
+  `Send`, required for `OnceCell<Pdfium>` to be `Sync` (and thus usable as a
+  `static`).
+
+---
+
 ## [0.9.1] — 2026-05-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name    = "edgequake-pdf2md"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.91"
 description  = "Convert PDF documents to Markdown using Vision Language Models — CLI and library"
@@ -40,7 +40,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Core
-pdfium-render  = { version = "0.8", features = ["pdfium_latest", "image_latest", "thread_safe"] }
+pdfium-render  = { version = "0.8", features = ["pdfium_latest", "image_latest", "sync"] }
 # Auto-download pdfium: zero-friction setup for end-users
 pdfium-auto    = { path = "crates/pdfium-auto", version = "0.3" }
 # v0.3.0 adds AWS Bedrock provider (Converse API) with 12 model families,

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -21,41 +21,87 @@ use crate::error::Pdf2MdError;
 use crate::output::DocumentMetadata;
 use edgequake_llm::ImageData;
 use image::DynamicImage;
+use once_cell::sync::OnceCell;
 use pdfium_render::prelude::*;
 use std::path::Path;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-/// Obtain a `Pdfium` instance via pdfium-auto.
+/// Process-wide pdfium singleton.
 ///
-/// When the `bundled` feature is active the pdfium shared library was embedded
-/// in the binary at compile time; it is extracted to the cache directory on
-/// first use and loaded from there (no network access required).
+/// Pdfium's `FPDF_InitLibrary`/`FPDF_DestroyLibrary` pair must be called at
+/// most once per process.  On Linux, if a `Pdfium` instance is dropped
+/// (triggering `FPDF_DestroyLibrary` + `dlclose`), the library code pages are
+/// unmapped; any later reference to pdfium function pointers — including those
+/// triggered by atexit/TLS destructors at process exit — causes SIGBUS.
 ///
-/// Without the `bundled` feature the library is downloaded on first use from
-/// <https://github.com/bblanchon/pdfium-binaries> and cached locally.
+/// Keeping one `Pdfium` alive for the entire process lifetime avoids this.
+static PDFIUM_SINGLETON: OnceCell<Pdfium> = OnceCell::new();
+/// If the first bind attempt failed, store the error message so subsequent
+/// callers get a consistent error without retrying the expensive dlopen path.
+static PDFIUM_BIND_ERROR: OnceCell<String> = OnceCell::new();
+
+/// Return a reference to the process-wide `Pdfium` instance.
+///
+/// The library is bound (and `FPDF_InitLibrary` is called) exactly once;
+/// subsequent calls return a reference to the same instance.  The instance
+/// is intentionally never dropped so that `FPDF_DestroyLibrary` is not called
+/// during the process lifetime, which would otherwise unmap the pdfium code
+/// pages and cause SIGBUS in cleanup handlers on Linux.
 ///
 /// # Errors
 /// Returns `Pdf2MdError::Internal` when the library cannot be loaded.  The
 /// error message includes a `PDFIUM_LIB_PATH` override hint.
-fn get_pdfium() -> Result<Pdfium, Pdf2MdError> {
-    #[cfg(feature = "bundled")]
-    {
-        pdfium_auto::bind_bundled().map_err(|e| {
-            Pdf2MdError::Internal(format!(
-                "PDFium library (bundled) unavailable: {e}\n\
-                 Hint: set PDFIUM_LIB_PATH=/path/to/libpdfium to use an existing copy."
-            ))
-        })
+fn get_pdfium() -> Result<&'static Pdfium, Pdf2MdError> {
+    // Fast path: already initialised or already known-failed.
+    if let Some(err) = PDFIUM_BIND_ERROR.get() {
+        return Err(make_bind_error(err));
+    }
+    if let Some(pdfium) = PDFIUM_SINGLETON.get() {
+        return Ok(pdfium);
     }
 
-    #[cfg(not(feature = "bundled"))]
-    pdfium_auto::bind_pdfium_silent().map_err(|e| {
-        Pdf2MdError::Internal(format!(
-            "PDFium library unavailable: {e}\n\
-             Hint: set PDFIUM_LIB_PATH=/path/to/libpdfium to use an existing copy."
-        ))
-    })
+    // Slow path: first call — bind the library.
+    let bind_result: Result<Pdfium, String> = {
+        #[cfg(feature = "bundled")]
+        {
+            pdfium_auto::bind_bundled().map_err(|e| {
+                format!(
+                    "PDFium library (bundled) unavailable: {e}\n\
+                     Hint: set PDFIUM_LIB_PATH=/path/to/libpdfium to use an existing copy."
+                )
+            })
+        }
+        #[cfg(not(feature = "bundled"))]
+        {
+            pdfium_auto::bind_pdfium_silent().map_err(|e| {
+                format!(
+                    "PDFium library unavailable: {e}\n\
+                     Hint: set PDFIUM_LIB_PATH=/path/to/libpdfium to use an existing copy."
+                )
+            })
+        }
+    };
+
+    match bind_result {
+        Ok(pdfium) => {
+            // `set` is a no-op if another thread raced us here; the winner's
+            // instance is returned either way.
+            let _ = PDFIUM_SINGLETON.set(pdfium);
+            Ok(PDFIUM_SINGLETON
+                .get()
+                .expect("just set above or already set"))
+        }
+        Err(msg) => {
+            let _ = PDFIUM_BIND_ERROR.set(msg.clone());
+            Err(make_bind_error(&msg))
+        }
+    }
+}
+
+#[inline]
+fn make_bind_error(msg: &str) -> Pdf2MdError {
+    Pdf2MdError::Internal(msg.to_owned())
 }
 
 /// Rasterise selected pages of a PDF into images.


### PR DESCRIPTION
## Problem

CI run #19 (v0.9.1) failed with `signal: 7, SIGBUS: access to undefined memory` at process exit during `cargo test --lib --no-default-features`.

**Root cause**: When a `Pdfium` instance was dropped inside `spawn_blocking`, it called `FPDF_DestroyLibrary` + `dlclose(libpdfium)`, which unmaps the pdfium code pages. On Linux, atexit/TLS destructors later trying to reference pdfium function pointers cause SIGBUS.

The cached pdfium library from the previous v0.9.0 Publish job was available via Swatinem/rust-cache, so pdfium successfully loaded in Pre-Publish Checks → FPDF_DestroyLibrary called on drop → SIGBUS.

## Fix

- `get_pdfium()` now returns `&'static Pdfium` backed by a `once_cell::sync::OnceCell` singleton
- `FPDF_InitLibrary` called exactly once; `FPDF_DestroyLibrary` never called during process lifetime
- Changed pdfium-render feature: `thread_safe` → `sync` (superset that adds `unsafe impl Send for Pdfium`, required for `OnceCell<Pdfium>: Sync`)

## Verification

All 79 lib tests pass with `--no-default-features --no-fail-fast`:
```
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.66s
```
`cargo clippy --no-default-features --features cli -- -D warnings` ✅  
`cargo fmt --all -- --check` ✅  
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features cli` ✅